### PR TITLE
Fix node creation for Globals to allow multiple globals

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -132,7 +132,7 @@ exports.sourceNodes = async (
     data.forEach((item) => {
       createNode({
         ...item,
-        id: createNodeId(`Global`),
+        id: createNodeId(`Global-${item.handle}`),
         parent: null,
         children: [],
         internal: {


### PR DESCRIPTION
Noticed trying to use Globals that only the last global comes through in GraphQL; Every global should have a handle, so used `item.handle` in `createNodeId` and works locally.